### PR TITLE
Updates wazero to its first beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/deadsy/sdfx v0.0.0-20220508165057-718104295925
-	github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142
+	github.com/tetratelabs/wazero v1.0.0-beta.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142 h1:ZnK50yYXmYRlAOpOzYw6Xu/QWU2kP8bDeVLQDzQtTas=
-github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v1.0.0-beta.1 h1:O5DZxiXG0WUUjuq4dwomA5gODRNnzF8LzQ+UOqGY5kY=
+github.com/tetratelabs/wazero v1.0.0-beta.1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 github.com/yofu/dxf v0.0.0-20190710012328-5a6d1e83f16c h1:qgsxLgTXCVH8Dxar36HI5af2ZfinVz5vF8erPpyzM+A=
 github.com/yofu/dxf v0.0.0-20190710012328-5a6d1e83f16c/go.mod h1:gnT4GQzgKW8+TLI0xheUgdmNV4dsAN0WJUVnztRZkfI=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/isosurface.go
+++ b/isosurface.go
@@ -20,19 +20,19 @@ type Renderer struct {
 	runtime wazero.Runtime // TODO: This should be closed
 }
 
+// ctx defaults until Renderer functions are context-aware.
+var ctx = context.Background()
+
 //goland:noinspection GoUnusedExportedFunction
 func NewRendererFast() *Renderer {
-	return &Renderer{runtime: wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigCompiler())}
+	return &Renderer{runtime: wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())}
 }
 
 func NewRendererCompatible() *Renderer {
-	return &Renderer{runtime: wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigInterpreter())}
+	return &Renderer{runtime: wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())}
 }
 
 func (r *Renderer) Render(sdf3 sdf.SDF3, meshCells int, output chan<- *render.Triangle3) {
-	// Choose the context to use for function calls.
-	ctx := context.Background()
-
 	// Prepare the imports for providing access to our SDF to the code
 	envModule := r.runtime.NewModuleBuilder("env")
 	envModule.ExportFunction("sdf_aabb", func(ctx context.Context, m api.Module) uint32 {


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io): 1.0.0-beta.1

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.