### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/deadsy/sdfx v0.0.0-20220508165057-718104295925
-	github.com/tetratelabs/wazero v1.0.0-beta.2
+	github.com/tetratelabs/wazero v1.0.0-pre.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
-github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/yofu/dxf v0.0.0-20190710012328-5a6d1e83f16c h1:qgsxLgTXCVH8Dxar36HI5af2ZfinVz5vF8erPpyzM+A=
 github.com/yofu/dxf v0.0.0-20190710012328-5a6d1e83f16c/go.mod h1:gnT4GQzgKW8+TLI0xheUgdmNV4dsAN0WJUVnztRZkfI=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/isosurface.go
+++ b/isosurface.go
@@ -34,79 +34,13 @@ func NewRendererCompatible() *Renderer {
 
 func (r *Renderer) Render(sdf3 sdf.SDF3, meshCells int, output chan<- *render.Triangle3) {
 	// Prepare the imports for providing access to our SDF to the code
-	envModule := r.runtime.NewModuleBuilder("env")
-	envModule.ExportFunction("sdf_aabb", func(ctx context.Context, m api.Module) uint32 {
-		box := sdf3.BoundingBox()
-		m.Memory().WriteFloat32Le(ctx, 0, float32(box.Min.X))
-		m.Memory().WriteFloat32Le(ctx, 4, float32(box.Min.Y))
-		m.Memory().WriteFloat32Le(ctx, 8, float32(box.Min.Z))
-		m.Memory().WriteFloat32Le(ctx, 12, float32(box.Max.X))
-		m.Memory().WriteFloat32Le(ctx, 16, float32(box.Max.Y))
-		m.Memory().WriteFloat32Le(ctx, 20, float32(box.Max.Z))
-		return 0
-	})
-	envModule.ExportFunction("sdf_eval", func(ctx context.Context, m api.Module, p uint32) float32 {
-		x, ok := m.Memory().ReadFloat32Le(ctx, p)
-		if !ok {
-			log.Panicln("Read out of range of memory")
-		}
-		y, ok := m.Memory().ReadFloat32Le(ctx, p+4)
-		if !ok {
-			log.Panicln("Read out of range of memory")
-		}
-		z, ok := m.Memory().ReadFloat32Le(ctx, p+8)
-		if !ok {
-			log.Panicln("Read out of range of memory")
-		}
-		return float32(sdf3.Evaluate(sdf.V3{X: float64(x), Y: float64(y), Z: float64(z)}))
-	})
-
-	// Prepare the import for receiving the results
-	envModule.ExportFunction("sdf_mesh_receiver", func(ctx context.Context, m api.Module,
-		verticesPtr uint32, verticesLen uint32, indicesPtr uint32, indicesLen uint32) {
-		//fmt.Println("Got solution with", verticesLen/3, "vertices and", indicesLen, "indices!")
-
-		// Read vertices from memory
-		memIndex := verticesPtr
-		var vertexCoords []float32
-		for i := 0; i < int(verticesLen); i++ {
-			coord, ok := m.Memory().ReadFloat32Le(ctx, memIndex)
-			if !ok {
-				log.Panicln("Read out of range of memory")
-			}
-			vertexCoords = append(vertexCoords, coord)
-			memIndex += 4
-		}
-
-		// Read indices from memory
-		memIndex = indicesPtr
-		var indices []uint32
-		for i := 0; i < int(verticesLen); i++ {
-			coord, ok := m.Memory().ReadUint32Le(ctx, memIndex)
-			if !ok {
-				log.Panicln("Read out of range of memory")
-			}
-			indices = append(indices, coord)
-			memIndex += 4
-		}
-
-		// Give the final triangles back to the user through the channel
-		//fmt.Println("[Sample] Vertices:", vertexCoords[:9], "- Indices:", indices[:3])
-		for faceIndex := 0; faceIndex < len(indices); faceIndex += 3 {
-			index0 := indices[faceIndex]
-			index1 := indices[faceIndex+1]
-			index2 := indices[faceIndex+2]
-			vertex0 := sdf.V3{X: float64(vertexCoords[index0*3]), Y: float64(vertexCoords[index0*3+1]), Z: float64(vertexCoords[index0*3+2])}
-			vertex1 := sdf.V3{X: float64(vertexCoords[index1*3]), Y: float64(vertexCoords[index1*3+1]), Z: float64(vertexCoords[index1*3+2])}
-			vertex2 := sdf.V3{X: float64(vertexCoords[index2*3]), Y: float64(vertexCoords[index2*3+1]), Z: float64(vertexCoords[index2*3+2])}
-			tri := &render.Triangle3{V: [3]sdf.V3{vertex0, vertex1, vertex2}}
-			//if faceIndex < 10 {
-			//	fmt.Println(" - ", tri)
-			//}
-			output <- tri
-		}
-	})
-	_, err := envModule.Instantiate(ctx, r.runtime)
+	h := &host{sdf3: sdf3, output: output}
+	_, err := r.runtime.NewHostModuleBuilder("env").
+		NewFunctionBuilder().WithFunc(h.aabb).Export("sdf_aabb").
+		NewFunctionBuilder().WithFunc(h.eval).Export("sdf_eval").
+		// Prepare the import for receiving the results
+		NewFunctionBuilder().WithFunc(h.meshReceiver).Export("sdf_mesh_receiver").
+		Instantiate(ctx, r.runtime)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -126,4 +60,79 @@ func (r *Renderer) Render(sdf3 sdf.SDF3, meshCells int, output chan<- *render.Tr
 
 func (r *Renderer) Info(_ sdf.SDF3, meshCells int) string {
 	return "Dual Contouring renderer (meshCells: " + strconv.Itoa(meshCells) + ")"
+}
+
+type host struct {
+	sdf3   sdf.SDF3
+	output chan<- *render.Triangle3
+}
+
+func (h *host) aabb(ctx context.Context, m api.Module) {
+	box := h.sdf3.BoundingBox()
+	m.Memory().WriteFloat32Le(ctx, 0, float32(box.Min.X))
+	m.Memory().WriteFloat32Le(ctx, 4, float32(box.Min.Y))
+	m.Memory().WriteFloat32Le(ctx, 8, float32(box.Min.Z))
+	m.Memory().WriteFloat32Le(ctx, 12, float32(box.Max.X))
+	m.Memory().WriteFloat32Le(ctx, 16, float32(box.Max.Y))
+	m.Memory().WriteFloat32Le(ctx, 20, float32(box.Max.Z))
+}
+
+func (h *host) eval(ctx context.Context, m api.Module, p uint32) float32 {
+	x, ok := m.Memory().ReadFloat32Le(ctx, p)
+	if !ok {
+		log.Panicln("Read out of range of memory")
+	}
+	y, ok := m.Memory().ReadFloat32Le(ctx, p+4)
+	if !ok {
+		log.Panicln("Read out of range of memory")
+	}
+	z, ok := m.Memory().ReadFloat32Le(ctx, p+8)
+	if !ok {
+		log.Panicln("Read out of range of memory")
+	}
+	return float32(h.sdf3.Evaluate(sdf.V3{X: float64(x), Y: float64(y), Z: float64(z)}))
+}
+
+func (h *host) meshReceiver(ctx context.Context, m api.Module, verticesPtr, verticesLen, indicesPtr, indicesLen uint32) {
+	//fmt.Println("Got solution with", verticesLen/3, "vertices and", indicesLen, "indices!")
+
+	// Read vertices from memory
+	memIndex := verticesPtr
+	var vertexCoords []float32
+	for i := 0; i < int(verticesLen); i++ {
+		coord, ok := m.Memory().ReadFloat32Le(ctx, memIndex)
+		if !ok {
+			log.Panicln("Read out of range of memory")
+		}
+		vertexCoords = append(vertexCoords, coord)
+		memIndex += 4
+	}
+
+	// Read indices from memory
+	memIndex = indicesPtr
+	var indices []uint32
+	for i := 0; i < int(indicesLen); i++ {
+		coord, ok := m.Memory().ReadUint32Le(ctx, memIndex)
+		if !ok {
+			log.Panicln("Read out of range of memory")
+		}
+		indices = append(indices, coord)
+		memIndex += 4
+	}
+
+	// Give the final triangles back to the user through the channel
+	//fmt.Println("[Sample] Vertices:", vertexCoords[:9], "- Indices:", indices[:3])
+	for faceIndex := 0; faceIndex < len(indices); faceIndex += 3 {
+		index0 := indices[faceIndex]
+		index1 := indices[faceIndex+1]
+		index2 := indices[faceIndex+2]
+		vertex0 := sdf.V3{X: float64(vertexCoords[index0*3]), Y: float64(vertexCoords[index0*3+1]), Z: float64(vertexCoords[index0*3+2])}
+		vertex1 := sdf.V3{X: float64(vertexCoords[index1*3]), Y: float64(vertexCoords[index1*3+1]), Z: float64(vertexCoords[index1*3+2])}
+		vertex2 := sdf.V3{X: float64(vertexCoords[index2*3]), Y: float64(vertexCoords[index2*3+1]), Z: float64(vertexCoords[index2*3+2])}
+		tri := &render.Triangle3{V: [3]sdf.V3{vertex0, vertex1, vertex2}}
+		//if faceIndex < 10 {
+		//	fmt.Println(" - ", tri)
+		//}
+		h.output <- tri
+	}
 }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

I also moved the host functions to the bottom of the file as it was a little cluttered looking.